### PR TITLE
Use sendmail(8) directly instead of relying on GNU mail(1).

### DIFF
--- a/gpg-remailer/cleartextmail/headers.cc
+++ b/gpg-remailer/cleartextmail/headers.cc
@@ -5,12 +5,13 @@ string ClearTextMail::headers() const
     string mime = d_headers.getHeader("MIME-Version");
 
     string contentHdr;
-
+    contentHdr += "From: " + d_replyTo + "\r\n";
+    contentHdr += subject() + "\r\n";
+    contentHdr += "Reply-To: " + d_replyTo + "\r\n";
     if (not mime.empty())
-        contentHdr = R"(-a ")" + String::escape(mime) + '"';
+        contentHdr += mime + "\r\n";
 
     d_headers.setHeaderIterator("Content-", MailHeaders::CASE_INITIAL);
-
     for 
     (
         auto begin = d_headers.beginh(), end = d_headers.endh();
@@ -39,7 +40,7 @@ string ClearTextMail::headers() const
                 header.erase(pos0, pos1 - pos0 - 1);
                 header[pos0] = ' ';
             }
-            contentHdr += R"( -a ")" + String::escape(header) + '"';
+            contentHdr += header + "\r\n";
         }
     }
     return contentHdr;

--- a/gpg-remailer/cleartextmail/mailcommand.cc
+++ b/gpg-remailer/cleartextmail/mailcommand.cc
@@ -2,8 +2,5 @@
 
 string ClearTextMail::mailCommand(string const &recipient) const
 {
-    return
-        "/usr/bin/mail -s '" + subject() + "' "
-                "-a \"Reply-To: " + d_replyTo + "\" " +
-                headers() + " " + recipient;
+    return "/usr/sbin/sendmail " + recipient;
 }

--- a/gpg-remailer/cleartextmail/writemailcontents.cc
+++ b/gpg-remailer/cleartextmail/writemailcontents.cc
@@ -8,5 +8,5 @@ void ClearTextMail::writeMailContents(std::string const &mailData) const
     ofstream out;
     Exception::open(out, d_mailName);
 
-    out << in.rdbuf();
+    out << headers() << "\r\n" << in.rdbuf();
 }

--- a/gpg-remailer/gpgmail/gpgmail.h
+++ b/gpg-remailer/gpgmail/gpgmail.h
@@ -28,6 +28,7 @@ class GPGMail: public Mailer<GPGMail>
                 std::string const &step);
 
     private:
+        std::string headers() const;
         static std::string makeBoundary();
 
             // Called through MailerBase:

--- a/gpg-remailer/gpgmail/headers.cc
+++ b/gpg-remailer/gpgmail/headers.cc
@@ -1,0 +1,13 @@
+#include "gpgmail.ih"
+
+string GPGMail::headers() const
+{
+    string contentHdr;
+    contentHdr += "From: " + d_replyTo + "\r\n";
+    contentHdr += subject() + "\r\n";
+    contentHdr += "Reply-To: " + d_replyTo + "\r\n";
+    contentHdr += "Content-Type: multipart/encrypted; "
+        "protocol=\"application/pgp-encrypted\"; "
+        "boundary=\"" + d_boundary + "\"";
+    return contentHdr;
+}

--- a/gpg-remailer/gpgmail/mailcommand.cc
+++ b/gpg-remailer/gpgmail/mailcommand.cc
@@ -2,12 +2,6 @@
 
 string GPGMail::mailCommand(string const &recipient) const
 {
-    return
-        "/usr/bin/mail -s '" + subject() + "' "
-                "-a \"Reply-To: " + d_replyTo + "\" "
-                "-a 'Content-Type: multipart/encrypted; "
-                    R"(protocol="application/pgp-encrypted"; )"
-                    R"(boundary=")" + d_boundary + R"("' )" +
-                recipient;
+    return "/usr/sbin/sendmail " + recipient;
 }
 

--- a/gpg-remailer/gpgmail/writemailcontents.cc
+++ b/gpg-remailer/gpgmail/writemailcontents.cc
@@ -8,20 +8,21 @@ void GPGMail::writeMailContents(string const &mailData) const
     ofstream out;
     Exception::open(out, d_mailName);
 
-    out << "\n"                         // create the mail to send.
-        "--" << d_boundary << "\n"
-        "Content-Type: application/pgp-encrypted\n"
-        "Content-Transfer-Encoding: 7bit\n"
-        "\n"
-        "Version: 1\n"
-        "\n"
-        "--" << d_boundary << "\n"
-        "Content-Type: application/octet-stream; name=gpg.asc\n"
-        "Content-Transfer-Encoding: 7bit\n"
-        "\n" <<
-        in.rdbuf() << "\n"
-        "\n"
-        "--" << d_boundary << "--\n";
+    out << headers() << // create the mail to send.
+        "\r\n"
+        "--" << d_boundary << "\r\n"
+        "Content-Type: application/pgp-encrypted\r\n"
+        "Content-Transfer-Encoding: 7bit\r\n"
+        "\r\n"
+        "Version: 1\r\n"
+        "\r\n"
+        "--" << d_boundary << "\r\n"
+        "Content-Type: application/octet-stream; name=gpg.asc\r\n"
+        "Content-Transfer-Encoding: 7bit\r\n"
+        "\r\n" <<
+        in.rdbuf() << "\r\n"
+        "\r\n"
+        "--" << d_boundary << "--\r\n";
 }
 
 


### PR DESCRIPTION
This change removes the dependency on GNU mailutils and allows any conforming sendmail(8) implementation to be used with gpg-remailer.